### PR TITLE
drop :always-thread-local sb-int:info

### DIFF
--- a/contrib/sb-fiber/fiber-ffi.lisp
+++ b/contrib/sb-fiber/fiber-ffi.lisp
@@ -76,10 +76,6 @@
           (format stream "~A ~A" name state)
           (format stream "~A" state)))))
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (setf (sb-int:info :variable :wired-tls '*current-fiber*)
-        :always-thread-local))
-
 (defvar *current-fiber* nil
   "Fiber currently running on this thread, or NIL.")
 


### PR DESCRIPTION
this forces initialization to NO_TLS_VALUE_MARKER, but it's no longer guaranteed to be initialized. compiler treats the marker as a lisp value: runtime tries to load it and promptly crashes